### PR TITLE
Page reviews och bilder bläddrar till höger med förlängd timer

### DIFF
--- a/Hotel.Client/Extensions/TimerExtensions.cs
+++ b/Hotel.Client/Extensions/TimerExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Timers;
+
+namespace Hotel.Client.Extensions
+{
+    public static class TimerExtensions
+    {
+        public static void Reset(this Timer timer)
+        {
+            timer.Stop();
+            timer.Start();
+        }
+    }
+}

--- a/Hotel.Client/Pages/Home/RollingReviews.razor.cs
+++ b/Hotel.Client/Pages/Home/RollingReviews.razor.cs
@@ -1,4 +1,5 @@
-﻿using Hotel.Client.ViewModel;
+﻿using Hotel.Client.Extensions;
+using Hotel.Client.ViewModel;
 using Hotel.Shared;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Configuration;
@@ -28,46 +29,39 @@ namespace Hotel.Client.Pages.Home
             foreach (var r in revs)
                 reviews.Add(new ReviewViewModel { Review = r });
             StateHasChanged();
-            StartTimer(3000);
+            StartTimer(5000);
         }
 
         private void StartTimer(int interval)
         {
-            timer = new Timer();
-            timer.Interval = interval;
+            timer = new Timer
+            {
+                Interval = interval,
+                AutoReset = true,
+                Enabled = true
+            };
             timer.Elapsed += ShowRandomImage;
-            timer.AutoReset = true;
-            timer.Enabled = true;
         }
 
         private void SlideRight()
         {
+            timer.Reset();
             if (displayIndex == Images.Count - 1)
-            {
                 displayIndex = 0;
-            }
             else
-            {
                 displayIndex++;
-            }
-            
+            StateHasChanged();
         }
 
         private void SlideLeft()
         {
+            timer.Reset();
             if (displayIndex == 0)
-            {
                 displayIndex = Images.Count;
-            }
             displayIndex--;
-        }
-
-        private void ShowRandomImage(object sender, ElapsedEventArgs e)
-        {
-            var random = new Random();
-            int num = random.Next(0, Images.Count);
-            displayIndex = num;
             StateHasChanged();
         }
+
+        private void ShowRandomImage(object sender, ElapsedEventArgs e) => SlideRight();
     }
 }

--- a/Hotel.Client/Pages/Home/RollingReviews.razor.css
+++ b/Hotel.Client/Pages/Home/RollingReviews.razor.css
@@ -77,7 +77,7 @@
     letter-spacing: 1px;
     font-size: 0.9rem;
     margin-bottom: 1rem;
-    overflow: auto hidden;
+    overflow: hidden;
     max-height: 180px;
 }
 .content .description::first-letter {


### PR DESCRIPTION
Page reviews och bilder på startsidan ska nu fungera på följande vis:

- 5 sekunders timer
- Bläddrar per automatik till höger
- Pilarna (manuell bläddring) gör en timer reset

Obs! Den "udda" tiden som kan ha upplevts var på grund av att bilderna slumpades, och ibland slumpade fram samma bild som tidigare. Denna funktionalitet finns inte längre kvar.

Issue g1-178, g1-132